### PR TITLE
Feature implementation from commits 629990d..3168614

### DIFF
--- a/client_server_test.go
+++ b/client_server_test.go
@@ -142,6 +142,7 @@ func sendRecv(t *testing.T, ws *Conn) {
 }
 
 func TestProxyDial(t *testing.T) {
+	t.Parallel()
 
 	s := newServer(t)
 	defer s.Close()
@@ -180,6 +181,7 @@ func TestProxyDial(t *testing.T) {
 }
 
 func TestProxyAuthorizationDial(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -220,6 +222,7 @@ func TestProxyAuthorizationDial(t *testing.T) {
 }
 
 func TestDial(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -232,6 +235,7 @@ func TestDial(t *testing.T) {
 }
 
 func TestDialCookieJar(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -294,6 +298,7 @@ func rootCAs(t *testing.T, s *httptest.Server) *x509.CertPool {
 }
 
 func TestDialTLS(t *testing.T) {
+	t.Parallel()
 	s := newTLSServer(t)
 	defer s.Close()
 
@@ -308,6 +313,7 @@ func TestDialTLS(t *testing.T) {
 }
 
 func TestDialTimeout(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -364,6 +370,7 @@ func (c *requireDeadlineNetConn) LocalAddr() net.Addr  { return c.c.LocalAddr() 
 func (c *requireDeadlineNetConn) RemoteAddr() net.Addr { return c.c.RemoteAddr() }
 
 func TestHandshakeTimeout(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -380,6 +387,7 @@ func TestHandshakeTimeout(t *testing.T) {
 }
 
 func TestHandshakeTimeoutInContext(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -401,6 +409,7 @@ func TestHandshakeTimeoutInContext(t *testing.T) {
 }
 
 func TestDialBadScheme(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -412,6 +421,7 @@ func TestDialBadScheme(t *testing.T) {
 }
 
 func TestDialBadOrigin(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -429,6 +439,7 @@ func TestDialBadOrigin(t *testing.T) {
 }
 
 func TestDialBadHeader(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -448,6 +459,7 @@ func TestDialBadHeader(t *testing.T) {
 }
 
 func TestBadMethod(t *testing.T) {
+	t.Parallel()
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ws, err := cstUpgrader.Upgrade(w, r, nil)
 		if err == nil {
@@ -476,6 +488,7 @@ func TestBadMethod(t *testing.T) {
 }
 
 func TestDialExtraTokensInRespHeaders(t *testing.T) {
+	t.Parallel()
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		challengeKey := r.Header.Get("Sec-Websocket-Key")
 		w.Header().Set("Upgrade", "foo, websocket")
@@ -493,6 +506,7 @@ func TestDialExtraTokensInRespHeaders(t *testing.T) {
 }
 
 func TestHandshake(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -519,6 +533,7 @@ func TestHandshake(t *testing.T) {
 }
 
 func TestRespOnBadHandshake(t *testing.T) {
+	t.Parallel()
 	const expectedStatus = http.StatusGone
 	const expectedBody = "This is the response body."
 
@@ -564,6 +579,7 @@ func (w testLogWriter) Write(p []byte) (int, error) {
 
 // TestHost tests handling of host names and confirms that it matches net/http.
 func TestHost(t *testing.T) {
+	t.Parallel()
 
 	upgrader := Upgrader{}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -745,6 +761,7 @@ func TestHost(t *testing.T) {
 }
 
 func TestDialCompression(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -759,6 +776,7 @@ func TestDialCompression(t *testing.T) {
 }
 
 func TestSocksProxyDial(t *testing.T) {
+	t.Parallel()
 	s := newServer(t)
 	defer s.Close()
 
@@ -846,6 +864,7 @@ func TestSocksProxyDial(t *testing.T) {
 }
 
 func TestTracingDialWithContext(t *testing.T) {
+	t.Parallel()
 
 	var headersWrote, requestWrote, getConn, gotConn, connectDone, gotFirstResponseByte bool
 	trace := &httptrace.ClientTrace{
@@ -905,6 +924,7 @@ func TestTracingDialWithContext(t *testing.T) {
 }
 
 func TestEmptyTracingDialWithContext(t *testing.T) {
+	t.Parallel()
 
 	trace := &httptrace.ClientTrace{}
 	ctx := httptrace.WithClientTrace(context.Background(), trace)
@@ -926,6 +946,7 @@ func TestEmptyTracingDialWithContext(t *testing.T) {
 
 // TestNetDialConnect tests selection of dial method between NetDial, NetDialContext, NetDialTLS or NetDialTLSContext
 func TestNetDialConnect(t *testing.T) {
+	t.Parallel()
 
 	upgrader := Upgrader{}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1101,6 +1122,7 @@ func TestNetDialConnect(t *testing.T) {
 	}
 }
 func TestNextProtos(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewUnstartedServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}),
 	)

--- a/client_test.go
+++ b/client_test.go
@@ -20,6 +20,7 @@ var hostPortNoPortTests = []struct {
 }
 
 func TestHostPortNoPort(t *testing.T) {
+	t.Parallel()
 	for _, tt := range hostPortNoPortTests {
 		hostPort, hostNoPort := hostPortNoPort(tt.u)
 		if hostPort != tt.hostPort {

--- a/compression.go
+++ b/compression.go
@@ -8,7 +8,6 @@ import (
 	"compress/flate"
 	"errors"
 	"io"
-	"log"
 	"strings"
 	"sync"
 )
@@ -135,9 +134,7 @@ func (r *flateReadWrapper) Read(p []byte) (int, error) {
 		// Preemptively place the reader back in the pool. This helps with
 		// scenarios where the application does not call NextReader() soon after
 		// this final read.
-		if err := r.Close(); err != nil {
-			log.Printf("websocket: flateReadWrapper.Close() returned error: %v", err)
-		}
+		_ = r.Close()
 	}
 	return n, err
 }

--- a/compression_test.go
+++ b/compression_test.go
@@ -12,6 +12,7 @@ type nopCloser struct{ io.Writer }
 func (nopCloser) Close() error { return nil }
 
 func TestTruncWriter(t *testing.T) {
+	t.Parallel()
 	const data = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijlkmnopqrstuvwxyz987654321"
 	for n := 1; n <= 10; n++ {
 		var b bytes.Buffer
@@ -71,6 +72,7 @@ func BenchmarkWriteWithCompression(b *testing.B) {
 }
 
 func TestValidCompressionLevel(t *testing.T) {
+	t.Parallel()
 	c := newTestConn(nil, nil, false)
 	for _, level := range []int{minCompressionLevel - 1, maxCompressionLevel + 1} {
 		if err := c.SetCompressionLevel(level); err == nil {

--- a/conn.go
+++ b/conn.go
@@ -1159,8 +1159,12 @@ func (c *Conn) SetCloseHandler(h func(code int, text string) error) {
 		h = func(code int, text string) error {
 			message := FormatCloseMessage(code, "")
 			err := c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
-			if err != nil && err != ErrCloseSent {
-				return err
+			if err != nil {
+				if _, ok := err.(net.Error); ok {
+					return nil
+				} else if err != ErrCloseSent {
+					return err
+				}
 			}
 			return nil
 		}

--- a/conn.go
+++ b/conn.go
@@ -1158,14 +1158,7 @@ func (c *Conn) SetCloseHandler(h func(code int, text string) error) {
 	if h == nil {
 		h = func(code int, text string) error {
 			message := FormatCloseMessage(code, "")
-			err := c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
-			if err != nil {
-				if _, ok := err.(net.Error); ok {
-					return nil
-				} else if err != ErrCloseSent {
-					return err
-				}
-			}
+			_ = c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
 			return nil
 		}
 	}

--- a/conn.go
+++ b/conn.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-	"log"
 	"net"
 	"strconv"
 	"strings"
@@ -490,9 +489,7 @@ func (c *Conn) beginMessage(mw *messageWriter, messageType int) error {
 	// probably better to return an error in this situation, but we cannot
 	// change this without breaking existing applications.
 	if c.writer != nil {
-		if err := c.writer.Close(); err != nil {
-			log.Printf("websocket: discarding writer close error: %v", err)
-		}
+		_ = c.writer.Close()
 		c.writer = nil
 	}
 
@@ -1021,9 +1018,7 @@ func (c *Conn) handleProtocolError(message string) error {
 func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
 	// Close previous reader, only relevant for decompression.
 	if c.reader != nil {
-		if err := c.reader.Close(); err != nil {
-			log.Printf("websocket: discarding reader close error: %v", err)
-		}
+		_ = c.reader.Close()
 		c.reader = nil
 	}
 

--- a/conn.go
+++ b/conn.go
@@ -1163,7 +1163,8 @@ func (c *Conn) SetCloseHandler(h func(code int, text string) error) {
 	if h == nil {
 		h = func(code int, text string) error {
 			message := FormatCloseMessage(code, "")
-			if err := c.WriteControl(CloseMessage, message, time.Now().Add(writeWait)); err != nil {
+			err := c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
+			if err != nil && err != ErrCloseSent {
 				return err
 			}
 			return nil

--- a/conn.go
+++ b/conn.go
@@ -454,13 +454,18 @@ func (c *Conn) WriteControl(messageType int, data []byte, deadline time.Time) er
 		}
 	}
 
-	timer := time.NewTimer(d)
 	select {
 	case <-c.mu:
-		timer.Stop()
-	case <-timer.C:
-		return errWriteTimeout
+	default:
+		timer := time.NewTimer(d)
+		select {
+		case <-c.mu:
+			timer.Stop()
+		case <-timer.C:
+			return errWriteTimeout
+		}
 	}
+
 	defer func() { c.mu <- struct{}{} }()
 
 	c.writeErrMu.Lock()

--- a/conn.go
+++ b/conn.go
@@ -1158,10 +1158,7 @@ func (c *Conn) SetCloseHandler(h func(code int, text string) error) {
 	if h == nil {
 		h = func(code int, text string) error {
 			message := FormatCloseMessage(code, "")
-			err := c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
-			if err != nil {
-				log.Printf("websocket: discarding close handler error: %v", err)
-			}
+			_ = c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
 			return nil
 		}
 	}

--- a/conn.go
+++ b/conn.go
@@ -1158,7 +1158,10 @@ func (c *Conn) SetCloseHandler(h func(code int, text string) error) {
 	if h == nil {
 		h = func(code int, text string) error {
 			message := FormatCloseMessage(code, "")
-			_ = c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
+			err := c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
+			if err != nil {
+				log.Printf("websocket: discarding close handler error: %v", err)
+			}
 			return nil
 		}
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -54,6 +54,7 @@ func newTestConn(r io.Reader, w io.Writer, isServer bool) *Conn {
 }
 
 func TestFraming(t *testing.T) {
+	t.Parallel()
 	frameSizes := []int{
 		0, 1, 2, 124, 125, 126, 127, 128, 129, 65534, 65535,
 		// 65536, 65537
@@ -148,6 +149,7 @@ func TestFraming(t *testing.T) {
 }
 
 func TestControl(t *testing.T) {
+	t.Parallel()
 	const message = "this is a ping/pong messsage"
 	for _, isServer := range []bool{true, false} {
 		for _, isWriteControl := range []bool{true, false} {
@@ -204,6 +206,7 @@ func (p *simpleBufferPool) Put(v interface{}) {
 }
 
 func TestWriteBufferPool(t *testing.T) {
+	t.Parallel()
 	const message = "Now is the time for all good people to come to the aid of the party."
 
 	var buf bytes.Buffer
@@ -282,6 +285,7 @@ func TestWriteBufferPool(t *testing.T) {
 
 // TestWriteBufferPoolSync ensures that *sync.Pool works as a buffer pool.
 func TestWriteBufferPoolSync(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var pool sync.Pool
 	wc := newConn(fakeNetConn{Writer: &buf}, true, 1024, 1024, &pool, nil, nil)
@@ -310,6 +314,7 @@ func (ew errorWriter) Write(p []byte) (int, error) { return 0, errors.New("error
 // TestWriteBufferPoolError ensures that buffer is returned to pool after error
 // on write.
 func TestWriteBufferPoolError(t *testing.T) {
+	t.Parallel()
 
 	// Part 1: Test NextWriter/Write/Close
 
@@ -353,6 +358,7 @@ func TestWriteBufferPoolError(t *testing.T) {
 }
 
 func TestCloseFrameBeforeFinalMessageFrame(t *testing.T) {
+	t.Parallel()
 	const bufSize = 512
 
 	expectedErr := &CloseError{Code: CloseNormalClosure, Text: "hello"}
@@ -385,6 +391,7 @@ func TestCloseFrameBeforeFinalMessageFrame(t *testing.T) {
 }
 
 func TestEOFWithinFrame(t *testing.T) {
+	t.Parallel()
 	const bufSize = 64
 
 	for n := 0; ; n++ {
@@ -422,6 +429,7 @@ func TestEOFWithinFrame(t *testing.T) {
 }
 
 func TestEOFBeforeFinalFrame(t *testing.T) {
+	t.Parallel()
 	const bufSize = 512
 
 	var b1, b2 bytes.Buffer
@@ -448,6 +456,7 @@ func TestEOFBeforeFinalFrame(t *testing.T) {
 }
 
 func TestWriteAfterMessageWriterClose(t *testing.T) {
+	t.Parallel()
 	wc := newTestConn(nil, &bytes.Buffer{}, false)
 	w, _ := wc.NextWriter(BinaryMessage)
 	if _, err := io.WriteString(w, "hello"); err != nil {
@@ -478,6 +487,7 @@ func TestWriteAfterMessageWriterClose(t *testing.T) {
 }
 
 func TestWriteHandlerDoesNotReturnErrCloseSent(t *testing.T) {
+	t.Parallel()
 	var b1, b2 bytes.Buffer
 
 	client := newTestConn(&b2, &b1, false)
@@ -498,6 +508,7 @@ func TestWriteHandlerDoesNotReturnErrCloseSent(t *testing.T) {
 }
 
 func TestReadLimit(t *testing.T) {
+	t.Parallel()
 	t.Run("Test ReadLimit is enforced", func(t *testing.T) {
 		const readLimit = 512
 		message := make([]byte, readLimit+1)
@@ -596,6 +607,7 @@ func TestReadLimit(t *testing.T) {
 }
 
 func TestAddrs(t *testing.T) {
+	t.Parallel()
 	c := newTestConn(nil, nil, true)
 	if c.LocalAddr() != localAddr {
 		t.Errorf("LocalAddr = %v, want %v", c.LocalAddr(), localAddr)
@@ -606,6 +618,7 @@ func TestAddrs(t *testing.T) {
 }
 
 func TestDeprecatedUnderlyingConn(t *testing.T) {
+	t.Parallel()
 	var b1, b2 bytes.Buffer
 	fc := fakeNetConn{Reader: &b1, Writer: &b2}
 	c := newConn(fc, true, 1024, 1024, nil, nil, nil)
@@ -616,6 +629,7 @@ func TestDeprecatedUnderlyingConn(t *testing.T) {
 }
 
 func TestNetConn(t *testing.T) {
+	t.Parallel()
 	var b1, b2 bytes.Buffer
 	fc := fakeNetConn{Reader: &b1, Writer: &b2}
 	c := newConn(fc, true, 1024, 1024, nil, nil, nil)
@@ -626,6 +640,7 @@ func TestNetConn(t *testing.T) {
 }
 
 func TestBufioReadBytes(t *testing.T) {
+	t.Parallel()
 	// Test calling bufio.ReadBytes for value longer than read buffer size.
 
 	m := make([]byte, 512)
@@ -668,6 +683,7 @@ var closeErrorTests = []struct {
 }
 
 func TestCloseError(t *testing.T) {
+	t.Parallel()
 	for _, tt := range closeErrorTests {
 		ok := IsCloseError(tt.err, tt.codes...)
 		if ok != tt.ok {
@@ -688,6 +704,7 @@ var unexpectedCloseErrorTests = []struct {
 }
 
 func TestUnexpectedCloseErrors(t *testing.T) {
+	t.Parallel()
 	for _, tt := range unexpectedCloseErrorTests {
 		ok := IsUnexpectedCloseError(tt.err, tt.codes...)
 		if ok != tt.ok {
@@ -709,6 +726,7 @@ func (w blockingWriter) Write(p []byte) (int, error) {
 }
 
 func TestConcurrentWritePanic(t *testing.T) {
+	t.Parallel()
 	w := blockingWriter{make(chan struct{}), make(chan struct{})}
 	c := newTestConn(nil, w, false)
 	go func() {
@@ -740,6 +758,7 @@ func (r failingReader) Read(p []byte) (int, error) {
 }
 
 func TestFailedConnectionReadPanic(t *testing.T) {
+	t.Parallel()
 	c := newTestConn(failingReader{}, nil, false)
 
 	defer func() {

--- a/example_test.go
+++ b/example_test.go
@@ -42,4 +42,4 @@ func processMessage(mt int, p []byte) {}
 
 // TestX prevents godoc from showing this entire file in the example. Remove
 // this function when a second example is added.
-func TestX(t *testing.T) {}
+func TestX(t *testing.T) { t.Parallel() }

--- a/examples/autobahn/server.go
+++ b/examples/autobahn/server.go
@@ -84,7 +84,7 @@ func echoCopyFull(w http.ResponseWriter, r *http.Request) {
 }
 
 // echoReadAll echoes messages from the client by reading the entire message
-// with ioutil.ReadAll.
+// with io.ReadAll.
 func echoReadAll(w http.ResponseWriter, r *http.Request, writeMessage, writePrepared bool) {
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {

--- a/examples/command/main.go
+++ b/examples/command/main.go
@@ -57,8 +57,6 @@ func pumpStdin(ws *websocket.Conn, w io.Writer) {
 }
 
 func pumpStdout(ws *websocket.Conn, r io.Reader, done chan struct{}) {
-	defer func() {
-	}()
 	s := bufio.NewScanner(r)
 	for s.Scan() {
 		ws.SetWriteDeadline(time.Now().Add(writeWait))

--- a/examples/filewatch/main.go
+++ b/examples/filewatch/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"flag"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -50,7 +49,8 @@ func readFileIfModified(lastMod time.Time) ([]byte, time.Time, error) {
 	if !fi.ModTime().After(lastMod) {
 		return nil, lastMod, nil
 	}
-	p, err := ioutil.ReadFile(filepath.Clean(filename))
+
+	p, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, fi.ModTime(), err
 	}

--- a/join_test.go
+++ b/join_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestJoinMessages(t *testing.T) {
+	t.Parallel()
 	messages := []string{"a", "bc", "def", "ghij", "klmno", "0", "12", "345", "6789"}
 	for _, readChunk := range []int{1, 2, 3, 4, 5, 6, 7} {
 		for _, term := range []string{"", ","} {

--- a/json_test.go
+++ b/json_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestJSON(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	wc := newTestConn(nil, &buf, true)
 	rc := newTestConn(&buf, nil, false)
@@ -38,6 +39,7 @@ func TestJSON(t *testing.T) {
 }
 
 func TestPartialJSONRead(t *testing.T) {
+	t.Parallel()
 	var buf0, buf1 bytes.Buffer
 	wc := newTestConn(nil, &buf0, true)
 	rc := newTestConn(&buf0, &buf1, false)
@@ -91,6 +93,7 @@ func TestPartialJSONRead(t *testing.T) {
 }
 
 func TestDeprecatedJSON(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	wc := newTestConn(nil, &buf, true)
 	rc := newTestConn(&buf, nil, false)

--- a/mask_test.go
+++ b/mask_test.go
@@ -29,6 +29,7 @@ func notzero(b []byte) int {
 }
 
 func TestMaskBytes(t *testing.T) {
+	t.Parallel()
 	key := [4]byte{1, 2, 3, 4}
 	for size := 1; size <= 1024; size++ {
 		for align := 0; align < wordSize; align++ {

--- a/server.go
+++ b/server.go
@@ -34,6 +34,7 @@ type Upgrader struct {
 	// size is zero, then buffers allocated by the HTTP server are used. The
 	// I/O buffer sizes do not limit the size of the messages that can be sent
 	// or received.
+	// The default value is 4096 bytes, 4kb.
 	ReadBufferSize, WriteBufferSize int
 
 	// WriteBufferPool is a pool of buffers for write operations. If the value

--- a/server.go
+++ b/server.go
@@ -174,13 +174,11 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 		}
 	}
 
-	h, ok := w.(http.Hijacker)
-	if !ok {
+	netConn, brw, err := http.NewResponseController(w).Hijack()
+	switch {
+	case errors.Is(err, errors.ErrUnsupported):
 		return u.returnError(w, r, http.StatusInternalServerError, "websocket: response does not implement http.Hijacker")
-	}
-	var brw *bufio.ReadWriter
-	netConn, brw, err := h.Hijack()
-	if err != nil {
+	case err != nil:
 		return u.returnError(w, r, http.StatusInternalServerError, err.Error())
 	}
 

--- a/server.go
+++ b/server.go
@@ -175,10 +175,7 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 	}
 
 	netConn, brw, err := http.NewResponseController(w).Hijack()
-	switch {
-	case errors.Is(err, errors.ErrUnsupported):
-		return u.returnError(w, r, http.StatusInternalServerError, "websocket: response does not implement http.Hijacker")
-	case err != nil:
+	if err != nil {
 		return u.returnError(w, r, http.StatusInternalServerError, err.Error())
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -27,6 +27,7 @@ var subprotocolTests = []struct {
 }
 
 func TestSubprotocols(t *testing.T) {
+	t.Parallel()
 	for _, st := range subprotocolTests {
 		r := http.Request{Header: http.Header{"Sec-Websocket-Protocol": {st.h}}}
 		protocols := Subprotocols(&r)
@@ -46,6 +47,7 @@ var isWebSocketUpgradeTests = []struct {
 }
 
 func TestIsWebSocketUpgrade(t *testing.T) {
+	t.Parallel()
 	for _, tt := range isWebSocketUpgradeTests {
 		ok := IsWebSocketUpgrade(&http.Request{Header: tt.h})
 		if tt.ok != ok {
@@ -55,6 +57,7 @@ func TestIsWebSocketUpgrade(t *testing.T) {
 }
 
 func TestSubProtocolSelection(t *testing.T) {
+	t.Parallel()
 	upgrader := Upgrader{
 		Subprotocols: []string{"foo", "bar", "baz"},
 	}
@@ -94,6 +97,7 @@ var checkSameOriginTests = []struct {
 }
 
 func TestCheckSameOrigin(t *testing.T) {
+	t.Parallel()
 	for _, tt := range checkSameOriginTests {
 		ok := checkSameOrigin(tt.r)
 		if tt.ok != ok {
@@ -120,6 +124,7 @@ var bufioReuseTests = []struct {
 }
 
 func TestBufioReuse(t *testing.T) {
+	t.Parallel()
 	for i, tt := range bufioReuseTests {
 		br := bufio.NewReaderSize(strings.NewReader(""), tt.n)
 		bw := bufio.NewWriterSize(&bytes.Buffer{}, tt.n)

--- a/server_test.go
+++ b/server_test.go
@@ -7,8 +7,10 @@ package websocket
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -150,5 +152,25 @@ func TestBufioReuse(t *testing.T) {
 		if reuse := &c.writeBuf[0] == &writeBuf[0]; reuse != tt.reuse {
 			t.Errorf("%d: write buffer reuse=%v, want %v", i, reuse, tt.reuse)
 		}
+	}
+}
+
+func TestHijack_NotSupported(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "upgrade")
+	req.Header.Set("Sec-Websocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	req.Header.Set("Sec-Websocket-Version", "13")
+
+	recorder := httptest.NewRecorder()
+
+	upgrader := Upgrader{}
+	_, err := upgrader.Upgrade(recorder, req, nil)
+
+	if want := (HandshakeError{}); !errors.As(err, &want) || recorder.Code != http.StatusInternalServerError {
+		t.Errorf("want %T and status_code=%d", want, http.StatusInternalServerError)
+		t.Fatalf("got err=%T and status_code=%d", err, recorder.Code)
 	}
 }

--- a/util_test.go
+++ b/util_test.go
@@ -21,6 +21,7 @@ var equalASCIIFoldTests = []struct {
 }
 
 func TestEqualASCIIFold(t *testing.T) {
+	t.Parallel()
 	for _, tt := range equalASCIIFoldTests {
 		eq := equalASCIIFold(tt.s, tt.t)
 		if eq != tt.eq {
@@ -44,6 +45,7 @@ var tokenListContainsValueTests = []struct {
 }
 
 func TestTokenListContainsValue(t *testing.T) {
+	t.Parallel()
 	for _, tt := range tokenListContainsValueTests {
 		h := http.Header{"Upgrade": {tt.value}}
 		ok := tokenListContainsValue(h, "Upgrade", "websocket")
@@ -64,6 +66,7 @@ var isValidChallengeKeyTests = []struct {
 }
 
 func TestIsValidChallengeKey(t *testing.T) {
+	t.Parallel()
 	for _, tt := range isValidChallengeKeyTests {
 		ok := isValidChallengeKey(tt.key)
 		if ok != tt.ok {
@@ -105,6 +108,7 @@ var parseExtensionTests = []struct {
 }
 
 func TestParseExtensions(t *testing.T) {
+	t.Parallel()
 	for _, tt := range parseExtensionTests {
 		h := http.Header{http.CanonicalHeaderKey("Sec-WebSocket-Extensions"): {tt.value}}
 		extensions := parseExtensions(h)


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `629990d..3168614`
**Files Changed:** 16 (16 programming files)
**Programming Ratio:** 100.0%

**Commits included:**
- fix: lint example
- perf: reduce timer in write_control
- perf: reduce timer in write_control
- Revert "Print log message"
- Print log message
- Do not return error in SetCloseHandler
- Do not handle network error in SetCloseHandler()
- fix: don't use errors.ErrUnsupported, it's available only since go1.21
- use http.ResposnseController
- make tests parallel
... and 5 more commits